### PR TITLE
5 profid launcher   create prod shortcut

### DIFF
--- a/src/ProfidLauncher.Tests/ProfidAppServiceTests.cs
+++ b/src/ProfidLauncher.Tests/ProfidAppServiceTests.cs
@@ -39,6 +39,7 @@ public class ProfidAppServiceTests
     [InlineData("ATRIUMP", 1234, false, "001-itsv-mprat2", "http://as400:1234/profoundui/atrium?workstnid=mprat2&suffixid=1")]
     [InlineData("ATRIUMP", 0, false, "032-ADNB-RES1", "http://032-itsv-as400.becom.at:8082/profoundui/atrium?workstnid=res1&suffixid=1")]
     [InlineData("ATRIUMCN", 0, false, "001-itsv-mprat2", "http://032-itsv-as400.becom.at:8082/profoundui/atrium?workstnid=mprat2&suffixid=1")]
+    [InlineData("ATRIUMCN", 0, false, "032-itsv-mprat2", "http://as400:8082/profoundui/atrium?workstnid=mprat2&suffixid=1")]
     public void Test_GetUrl_OK(string operationMode, int port, bool useSecure, string hostName, string resultUrl)
     {
         var config = ProfidAppExtensions.GetProfidAppConfiguration(new CommandLineOptions { OperationMode = operationMode, Port = port, UseSecure = useSecure }, hostName);

--- a/src/ProfidLauncher/ProfidLauncher.csproj
+++ b/src/ProfidLauncher/ProfidLauncher.csproj
@@ -51,16 +51,16 @@
   
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
-    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3595.46" />
-    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.135" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.4129.50" />
+    <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.142" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
-    <PackageReference Include="System.Drawing.Common" Version="10.0.0" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.11" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/ProfidLauncher/Properties/launchSettings.json
+++ b/src/ProfidLauncher/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "ProfidLauncher": {
       "commandName": "Project",
-      "commandLineArgs": "-m ATRIUMD"
+      "commandLineArgs": "-m ATRIUMP"
     }
   }
 }

--- a/src/ProfidLauncher/Services/ProfidAppService.cs
+++ b/src/ProfidLauncher/Services/ProfidAppService.cs
@@ -84,7 +84,7 @@ public class ProfidAppService
                 host = _profidConfig.Site == Sites.HEYUAN ? _settings.China : _settings.Test;
                 break;
             case Models.System.CHINA:
-                host = _settings.China;
+                host = _profidConfig.Site == Sites.HEYUAN ? _settings.Prod : _settings.China;
                 break;
             default:
                 host = _settings.Prod;


### PR DESCRIPTION
updated all the packages
as mentioned in commit
Same behavior for mode ATRIUMP in CN is now with mode ATRIUMCN
 -> Europe Machine
   -> ATRIUMP launches ATRIUMP
   -> ATRIUMCN launches ATRIUMCN in China
 -> CN Machine
  -> ATRIUMP launches ATRIUMCN
  -> NEW: ATRIUMCN launches ATRIUMP